### PR TITLE
Split GitHub Actions workflow into separate build-test and deploy wor…

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,64 +1,39 @@
-name: Build and Deploy
+name: Deploy
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Build and Test"]
+
+    types:
+      - completed
+
     branches:
       - main
 
-    paths:
-      - '.github/workflows/**'
-      - 'Cargo**'
-      - 'src/**/*.rs'
-
 jobs:
-  build-and-package:
-    runs-on: ubuntu-24.04-arm
-
-    env:
-      BUILD_TARGET: aarch64-unknown-linux-musl
-      PROJECT: lambdupdate
-
+  check-workflow-success:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    outputs:
+      success: ${{ steps.check.outputs.success }}
     steps:
-      - uses: actions/checkout@v4
+      - id: check
+        run: echo "success=true" >> $GITHUB_OUTPUT
 
-      - name: Update and Configure Rust
-        run: |
-          sudo apt-get install -y musl-tools
-          rustup target add ${{ env.BUILD_TARGET }}
-          rustup update
-          rustup component add clippy
-
-      - name: Dump Toolchain Info
-        run: |
-          cargo --version --verbose
-          rustc --version
-          cargo clippy --version
-
-      - name: Build
-        run: cargo build --target ${{ env.BUILD_TARGET }}
-
-      - name: Test
-        run: cargo test --target ${{ env.BUILD_TARGET }}
-
-      - name: Lint
-        run: cargo clippy --target ${{ env.BUILD_TARGET }} -- -D warnings
-
-      - name: Package
-        run: |
-          cargo build --release --target ${{ env.BUILD_TARGET }}
-          cp target/${{ env.BUILD_TARGET }}/release/lambda bootstrap
-          zip -j ${{ env.PROJECT }}.zip bootstrap
-
-      - name: Upload Package
-        uses: actions/upload-artifact@v4
+  download-package:
+    needs: check-workflow-success
+    if: needs.check-workflow-success.outputs.success == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Package Artifact
+        uses: dawidd6/action-download-artifact@v3
         with:
+          workflow: build-test.yml
           name: package
-          path: ${{ env.PROJECT }}.zip
-          retention-days: 1
+          path: .
 
   deploy-us-east-1:
-    needs: build-and-package
-
+    needs: download-package
     uses: ./.github/workflows/deploy-lambda.yml
     with:
       aws-region: us-east-1
@@ -67,8 +42,7 @@ jobs:
       bucket-name: ${{ secrets.AWS_US_EAST_1_BUCKET }}
 
   deploy-us-east-2:
-    needs: build-and-package
-
+    needs: download-package
     uses: ./.github/workflows/deploy-lambda.yml
     with:
       aws-region: us-east-2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,63 @@
+name: Build and Test
+
+on:
+  push:
+    branches:
+      - main
+
+    paths:
+      - '.github/workflows/**'
+      - 'Cargo**'
+      - 'src/**/*.rs'
+
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-24.04-arm
+
+    env:
+      BUILD_TARGET: aarch64-unknown-linux-musl
+      PROJECT: lambdupdate
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update and Configure Rust
+        run: |
+          sudo apt-get install -y musl-tools
+          rustup target add ${{ env.BUILD_TARGET }}
+          rustup update
+          rustup component add clippy
+
+      - name: Dump Toolchain Info
+        run: |
+          cargo --version --verbose
+          rustc --version
+          cargo clippy --version
+
+      - name: Build
+        run: cargo build --target ${{ env.BUILD_TARGET }}
+
+      - name: Test
+        run: cargo test --target ${{ env.BUILD_TARGET }}
+
+      - name: Lint
+        run: cargo clippy --target ${{ env.BUILD_TARGET }} -- -D warnings
+
+      - name: Package
+        if: github.event_name == 'push'
+        run: |
+          cargo build --release --target ${{ env.BUILD_TARGET }}
+          cp target/${{ env.BUILD_TARGET }}/release/lambda bootstrap
+          zip -j ${{ env.PROJECT }}.zip bootstrap
+
+      - name: Upload Package
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: package
+          path: ${{ env.PROJECT }}.zip
+          retention-days: 1


### PR DESCRIPTION
…kflows

- Create build-and-test.yml that runs on PRs and main pushes
- Build-test runs build, test, and clippy on all triggers
- Package/upload steps only run on main pushes, not PRs
- Convert build-and-deploy.yml to deploy-only workflow
- Deploy workflow triggers after successful build-test completion on main
- Use workflow_run trigger and artifact download for clean separation

🤖 Generated with [Claude Code](https://claude.ai/code)