### PR TITLE
Propagate update errors, dedup, retry on conflict, add async DLQ

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "http 1.4.0",
+ "http 1.4.1",
  "sha1 0.10.6",
  "time",
  "tokio",
@@ -206,7 +206,7 @@ dependencies = [
  "bytes-utils",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "percent-encoding",
@@ -235,7 +235,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
@@ -265,7 +265,7 @@ dependencies = [
  "hex",
  "hmac 0.13.0",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "lru",
  "percent-encoding",
@@ -294,7 +294,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
@@ -318,7 +318,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
@@ -343,7 +343,7 @@ dependencies = [
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
@@ -365,7 +365,7 @@ dependencies = [
  "hex",
  "hmac 0.13.0",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "p256",
  "percent-encoding",
  "sha2 0.11.0",
@@ -397,7 +397,7 @@ dependencies = [
  "bytes",
  "crc-fast",
  "hex",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "md-5",
@@ -431,7 +431,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "percent-encoding",
@@ -452,7 +452,7 @@ dependencies = [
  "h2 0.3.27",
  "h2 0.4.14",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 0.4.6",
  "hyper 0.14.32",
  "hyper 1.9.0",
@@ -516,7 +516,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -537,7 +537,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -563,7 +563,7 @@ checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "http 1.4.0",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -577,7 +577,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -626,7 +626,7 @@ dependencies = [
  "bytes",
  "chrono",
  "flate2",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-serde",
  "query_map",
@@ -1302,7 +1302,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http 1.4.1",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -1370,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1396,7 +1396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -1407,7 +1407,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -1418,7 +1418,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.1",
  "serde",
 ]
 
@@ -1478,7 +1478,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2 0.4.14",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "httparse",
  "itoa",
@@ -1509,7 +1509,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.1",
  "hyper 1.9.0",
  "hyper-util",
  "rustls 0.23.40",
@@ -1529,7 +1529,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "hyper 1.9.0",
  "ipnet",
@@ -1719,7 +1719,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 [[package]]
 name = "jluszcz_rust_utils"
 version = "0.1.0"
-source = "git+https://github.com//jluszcz/rust-utils#c7ee494776dccdc05c274f91e939272607c51686"
+source = "git+https://github.com/jluszcz/rust-utils#46a05dcf361dd9bcd5d5698843cf02ed3fc0e4de"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1760,7 +1760,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body-util",
  "http-serde",
  "hyper 1.9.0",
@@ -1784,7 +1784,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
@@ -1830,15 +1830,6 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
-
-[[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -1959,29 +1950,6 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "sha2 0.10.9",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
 ]
 
 [[package]]
@@ -2107,15 +2075,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -2307,12 +2266,6 @@ dependencies = [
  "serde",
  "serde_json",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"
@@ -2717,7 +2670,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.6.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ aws_lambda_events = "1.0"
 chrono = "0.4"
 clap = "4.5"
 futures = "0.3"
-jluszcz_rust_utils = { git = "https://github.com//jluszcz/rust-utils" }
+jluszcz_rust_utils = { git = "https://github.com/jluszcz/rust-utils" }
 lambda_runtime = "1.*"
 log = "0.4"
 serde_json = "1.0"
-tokio = { version = "1.*", features = ["full"] }
+tokio = { version = "1.*", features = ["macros", "rt-multi-thread", "time"] }
 
 [[bin]]
 name = "main"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ runs on `arm64` (`aarch64-unknown-linux-musl`) using the `provided.al2023` runti
 
 ``` bash
 export TF_VAR_aws_region="us-east-1"
-export TF_VAR_aws_acct_id="123412341234"
 ```
 
 - Build and package the Lambda binary

--- a/lambdupdate.tf
+++ b/lambdupdate.tf
@@ -138,10 +138,43 @@ resource "aws_lambda_function" "lambdupdate" {
   architectures = ["arm64"]
   runtime       = "provided.al2023"
   handler       = "ignored"
-  publish       = "false"
+  publish       = false
   description   = "Update Lambdas from code in ${data.aws_s3_bucket.code_bucket.bucket}"
   timeout       = 5
   memory_size   = 128
+}
+
+resource "aws_sqs_queue" "dlq" {
+  name                      = "lambdupdate-dlq"
+  message_retention_seconds = 1209600
+}
+
+data "aws_iam_policy_document" "dlq" {
+  statement {
+    actions   = ["sqs:SendMessage"]
+    resources = [aws_sqs_queue.dlq.arn]
+  }
+}
+
+resource "aws_iam_policy" "dlq" {
+  name   = "lambdupdate.dlq.${var.aws_region}"
+  policy = data.aws_iam_policy_document.dlq.json
+}
+
+resource "aws_iam_role_policy_attachment" "dlq" {
+  role       = aws_iam_role.lambdupdate.name
+  policy_arn = aws_iam_policy.dlq.arn
+}
+
+resource "aws_lambda_function_event_invoke_config" "lambdupdate" {
+  function_name          = aws_lambda_function.lambdupdate.function_name
+  maximum_retry_attempts = 0
+
+  destination_config {
+    on_failure {
+      destination = aws_sqs_queue.dlq.arn
+    }
+  }
 }
 
 data "aws_iam_openid_connect_provider" "github" {

--- a/src/lambda.rs
+++ b/src/lambda.rs
@@ -5,14 +5,14 @@ use serde_json::{Value, json};
 
 #[tokio::main]
 async fn main() -> Result<(), lambda_runtime::Error> {
+    lambda::init(APP_NAME, module_path!(), false).await?;
+
     let func = service_fn(function);
     lambda_runtime::run(func).await?;
     Ok(())
 }
 
 async fn function(event: LambdaEvent<Value>) -> Result<Value, lambda_runtime::Error> {
-    lambda::init(APP_NAME, module_path!(), false).await?;
-
     update(serde_json::from_value(event.payload)?).await?;
 
     Ok(json!({}))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,20 +3,25 @@
 //! This library processes S3 events triggered when ZIP files are uploaded to a code bucket,
 //! extracts function names from object metadata or keys, and updates the corresponding Lambda functions.
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use aws_config::ConfigLoader;
 use aws_lambda_events::s3::{S3Event, S3EventRecord};
 use aws_sdk_lambda::config::Region;
-use aws_sdk_s3::operation::head_object::HeadObjectOutput;
+use aws_sdk_lambda::operation::update_function_code::UpdateFunctionCodeError;
 use chrono::Utc;
 use futures::future::try_join_all;
-use log::{debug, info};
-use std::collections::HashSet;
-use std::fmt::Display;
+use log::{debug, info, warn};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::sleep;
 
 pub const APP_NAME: &str = "lambdupdate";
 
 const FUNCTION_NAME_MD_KEY: &str = "function.names";
+
+const MAX_UPDATE_ATTEMPTS: u32 = 3;
+const INITIAL_BACKOFF_MS: u64 = 500;
 
 /// Creates an S3EventRecord for testing or CLI usage.
 ///
@@ -97,32 +102,38 @@ fn get_region(records: &[S3EventRecord]) -> Result<String> {
     }
 }
 
+/// Fetches function names from the object's S3 metadata.
+///
+/// Returns `Ok(Some(_))` if the object's metadata contains the function-names key,
+/// `Ok(None)` if the head succeeds but the key is absent, and `Err(_)` if HeadObject
+/// itself fails — callers must treat that as a real error rather than silently
+/// falling back, since it usually indicates misconfigured IAM or a missing object.
 async fn get_function_names_from_md(
     s3_client: &aws_sdk_s3::Client,
     bucket: &str,
     key: &str,
-) -> Option<String> {
+) -> Result<Option<String>> {
     debug!("Head Object: {bucket}:{key}");
-    let head_object_output = s3_client.head_object().bucket(bucket).key(key).send().await;
-    get_function_names_from_head_object_output(head_object_output, bucket, key)
+    let head_object_output = s3_client
+        .head_object()
+        .bucket(bucket)
+        .key(key)
+        .send()
+        .await
+        .with_context(|| format!("HeadObject failed for {bucket}:{key}"))?;
+
+    info!("Head Object Succeeded: {bucket}:{key}");
+    debug!("Object Metadata: {:?}", head_object_output.metadata);
+
+    Ok(extract_function_names_from_metadata(
+        head_object_output.metadata,
+    ))
 }
 
-fn get_function_names_from_head_object_output<E>(
-    head_object_output: Result<HeadObjectOutput, E>,
-    bucket: &str,
-    key: &str,
+fn extract_function_names_from_metadata(
+    metadata: Option<HashMap<String, String>>,
 ) -> Option<String> {
-    if let Ok(head_object_output) = head_object_output {
-        info!("Head Object Succeeded: {bucket}:{key}");
-
-        let object_md = head_object_output.metadata;
-        debug!("Object Metadata: {object_md:?}");
-
-        object_md.and_then(|m| m.get(FUNCTION_NAME_MD_KEY).cloned())
-    } else {
-        info!("Head Object Failed for {bucket}:{key} - will use object key for function name");
-        None
-    }
+    metadata.and_then(|m| m.get(FUNCTION_NAME_MD_KEY).cloned())
 }
 
 /// Determines function names from object metadata or object key.
@@ -139,14 +150,11 @@ fn get_function_names_from_head_object_output<E>(
 ///
 /// # Errors
 /// * Returns error if no metadata is provided and the key doesn't end with ".zip"
-fn get_function_names<S>(function_names_from_md: Option<S>, key: &str) -> Result<String>
-where
-    S: Into<String> + Display,
-{
-    let function_names = match function_names_from_md {
+fn get_function_names(function_names_from_md: Option<String>, key: &str) -> Result<String> {
+    match function_names_from_md {
         Some(function_names) => {
             debug!("Function names from object metadata: {function_names}");
-            function_names.into()
+            Ok(function_names)
         }
         None => {
             let function_name = key
@@ -154,11 +162,9 @@ where
                 .ok_or_else(|| anyhow!("'.zip' not found in object key: {key}"))?;
 
             debug!("Function name from object key: {function_name}");
-            function_name.to_string()
+            Ok(function_name.to_string())
         }
-    };
-
-    Ok(function_names)
+    }
 }
 
 /// Processes a comma-separated list of function names, trimming whitespace and filtering empty names.
@@ -193,25 +199,69 @@ fn process_function_names(function_names: &str) -> Result<Vec<String>> {
     }
 }
 
+fn collect_update_tasks(
+    function_names_md: Option<String>,
+    bucket: Arc<str>,
+    key: Arc<str>,
+    update_tasks: &mut HashSet<(String, Arc<str>, Arc<str>)>,
+) -> Result<()> {
+    let function_names = get_function_names(function_names_md, &key)?;
+    let processed_names = process_function_names(&function_names)?;
+
+    for function_name in processed_names {
+        update_tasks.insert((function_name, Arc::clone(&bucket), Arc::clone(&key)));
+    }
+
+    Ok(())
+}
+
+fn is_conflict(err: Option<&UpdateFunctionCodeError>) -> bool {
+    matches!(
+        err,
+        Some(UpdateFunctionCodeError::ResourceConflictException(_))
+    )
+}
+
 async fn update_code(
     lambda_client: aws_sdk_lambda::Client,
     function_name: String,
-    bucket: String,
-    key: String,
+    bucket: Arc<str>,
+    key: Arc<str>,
 ) -> Result<()> {
     debug!("Update Function Code: {function_name} <-- {bucket}:{key}");
 
-    lambda_client
-        .update_function_code()
-        .function_name(&function_name)
-        .s3_bucket(&bucket)
-        .s3_key(&key)
-        .send()
-        .await?;
+    let mut attempt = 0u32;
+    let final_err = loop {
+        attempt += 1;
 
-    info!("Update Function Code Succeeded: {function_name} <-- {bucket}:{key}");
+        let result = lambda_client
+            .update_function_code()
+            .function_name(&function_name)
+            .s3_bucket(bucket.as_ref())
+            .s3_key(key.as_ref())
+            .send()
+            .await;
 
-    Ok(())
+        match result {
+            Ok(_) => {
+                info!("Update Function Code Succeeded: {function_name} <-- {bucket}:{key}");
+                return Ok(());
+            }
+            Err(err) => {
+                if !is_conflict(err.as_service_error()) || attempt >= MAX_UPDATE_ATTEMPTS {
+                    break err;
+                }
+
+                let backoff_ms = INITIAL_BACKOFF_MS * (1u64 << (attempt - 1));
+                warn!(
+                    "ResourceConflictException updating {function_name} (attempt {attempt}/{MAX_UPDATE_ATTEMPTS}); retrying in {backoff_ms}ms"
+                );
+                sleep(Duration::from_millis(backoff_ms)).await;
+            }
+        }
+    };
+
+    Err(final_err).with_context(|| format!("UpdateFunctionCode failed for {function_name}"))
 }
 
 /// Main function to process S3 events and update Lambda functions.
@@ -240,46 +290,42 @@ pub async fn update(event: S3Event) -> Result<()> {
     let s3_client = aws_sdk_s3::Client::new(&aws_config);
     let lambda_client = aws_sdk_lambda::Client::new(&aws_config);
 
-    let mut update_tasks = Vec::new();
+    let mut update_tasks: HashSet<(String, Arc<str>, Arc<str>)> = HashSet::new();
 
     for record in event.records {
         debug!("Record: {record:?}");
 
-        let bucket = record
-            .s3
-            .bucket
-            .name
-            .as_ref()
-            .ok_or_else(|| anyhow!("Bucket not found in {record:?}"))?;
+        let bucket: Arc<str> = Arc::from(
+            record
+                .s3
+                .bucket
+                .name
+                .as_deref()
+                .ok_or_else(|| anyhow!("Bucket not found in {record:?}"))?,
+        );
 
-        let key = record
-            .s3
-            .object
-            .key
-            .as_ref()
-            .ok_or_else(|| anyhow!("Key not found in {record:?}"))?;
+        let key: Arc<str> = Arc::from(
+            record
+                .s3
+                .object
+                .key
+                .as_deref()
+                .ok_or_else(|| anyhow!("Key not found in {record:?}"))?,
+        );
 
-        let function_names = get_function_names_from_md(&s3_client, bucket, key).await;
-        let function_names = get_function_names(function_names, key)?;
-        let processed_names = process_function_names(&function_names)?;
-
-        for function_name in processed_names {
-            update_tasks.push((function_name, bucket.clone(), key.clone()));
-        }
+        let function_names_md = get_function_names_from_md(&s3_client, &bucket, &key).await?;
+        collect_update_tasks(function_names_md, bucket, key, &mut update_tasks)?;
     }
 
-    let mut update_code_futures = Vec::with_capacity(update_tasks.len());
-    for (function_name, bucket, key) in update_tasks {
-        update_code_futures.push(tokio::spawn(update_code(
-            lambda_client.clone(),
-            function_name,
-            bucket,
-            key,
-        )));
-    }
+    debug!("{} function(s) to update", update_tasks.len());
 
-    debug!("{} function(s) to update", update_code_futures.len());
-    try_join_all(update_code_futures).await?;
+    let update_futures = update_tasks
+        .into_iter()
+        .map(|(function_name, bucket, key)| {
+            update_code(lambda_client.clone(), function_name, bucket, key)
+        });
+
+    try_join_all(update_futures).await?;
 
     Ok(())
 }
@@ -287,7 +333,6 @@ pub async fn update(event: S3Event) -> Result<()> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use anyhow::Error;
     use aws_lambda_events::s3::S3EventRecord;
     use std::collections::HashMap;
 
@@ -359,8 +404,8 @@ mod test {
     }
 
     #[test]
-    fn test_get_function_names_from_md() -> Result<()> {
-        let function_names = get_function_names(Some("foo,bar"), "bar")?;
+    fn test_get_function_names_when_md_provided() -> Result<()> {
+        let function_names = get_function_names(Some("foo,bar".to_string()), "bar")?;
 
         assert_eq!("foo,bar", function_names);
 
@@ -369,7 +414,7 @@ mod test {
 
     #[test]
     fn test_get_function_names_from_key() -> Result<()> {
-        let function_names = get_function_names(None::<&str>, "bar.zip")?;
+        let function_names = get_function_names(None, "bar.zip")?;
 
         assert_eq!("bar", function_names);
 
@@ -378,7 +423,7 @@ mod test {
 
     #[test]
     fn test_get_function_names_from_unzipped_key() {
-        let res = get_function_names(None::<&str>, "bar");
+        let res = get_function_names(None, "bar");
 
         assert!(res.is_err());
         if let Err(e) = res {
@@ -387,52 +432,27 @@ mod test {
     }
 
     #[test]
-    fn test_get_function_names_from_head_object_output() {
-        let fn_names = "foo,bar";
+    fn test_extract_function_names_present() {
+        let mut md = HashMap::new();
+        md.insert(FUNCTION_NAME_MD_KEY.to_string(), "foo,bar".to_string());
 
-        let output: Result<HeadObjectOutput, Error> = Ok(HeadObjectOutput::builder()
-            .metadata(FUNCTION_NAME_MD_KEY, fn_names)
-            .build());
-
-        let fn_names_from_output =
-            get_function_names_from_head_object_output(output, "bucket", "key");
-
-        assert!(fn_names_from_output.is_some());
-        if let Some(fn_names_from_output) = fn_names_from_output {
-            assert_eq!(fn_names, fn_names_from_output);
-        }
+        assert_eq!(
+            Some("foo,bar".to_string()),
+            extract_function_names_from_metadata(Some(md))
+        );
     }
 
     #[test]
-    fn test_get_function_names_from_head_object_output_err() {
-        let output: Result<HeadObjectOutput, Error> = Err(anyhow!("Error!"));
-
-        let fn_names_from_output =
-            get_function_names_from_head_object_output(output, "bucket", "key");
-
-        assert!(fn_names_from_output.is_none());
+    fn test_extract_function_names_no_metadata() {
+        assert_eq!(None, extract_function_names_from_metadata(None));
     }
 
     #[test]
-    fn test_get_function_names_from_head_object_output_no_metadata() {
-        let output: Result<HeadObjectOutput, Error> = Ok(HeadObjectOutput::builder().build());
-
-        let fn_names_from_output =
-            get_function_names_from_head_object_output(output, "bucket", "key");
-
-        assert!(fn_names_from_output.is_none());
-    }
-
-    #[test]
-    fn test_get_function_names_from_head_object_output_no_function_names() {
-        let output: Result<HeadObjectOutput, Error> = Ok(HeadObjectOutput::builder()
-            .set_metadata(Some(HashMap::new()))
-            .build());
-
-        let fn_names_from_output =
-            get_function_names_from_head_object_output(output, "bucket", "key");
-
-        assert!(fn_names_from_output.is_none());
+    fn test_extract_function_names_key_absent() {
+        assert_eq!(
+            None,
+            extract_function_names_from_metadata(Some(HashMap::new()))
+        );
     }
 
     #[test]
@@ -469,6 +489,101 @@ mod test {
     fn test_process_function_names_mixed() -> Result<()> {
         let processed = process_function_names("func1,,func2, ,func3")?;
         assert_eq!(vec!["func1", "func2", "func3"], processed);
+        Ok(())
+    }
+
+    #[test]
+    fn test_is_conflict_true() {
+        let err = UpdateFunctionCodeError::ResourceConflictException(
+            aws_sdk_lambda::types::error::ResourceConflictException::builder()
+                .message("update in progress")
+                .build(),
+        );
+        assert!(is_conflict(Some(&err)));
+    }
+
+    #[test]
+    fn test_is_conflict_false_other_variant() {
+        let err = UpdateFunctionCodeError::TooManyRequestsException(
+            aws_sdk_lambda::types::error::TooManyRequestsException::builder()
+                .message("throttled")
+                .build(),
+        );
+        assert!(!is_conflict(Some(&err)));
+    }
+
+    #[test]
+    fn test_is_conflict_false_none() {
+        assert!(!is_conflict(None));
+    }
+
+    #[test]
+    fn test_collect_update_tasks_dedups_identical_records() -> Result<()> {
+        let bucket: Arc<str> = Arc::from("b");
+        let key: Arc<str> = Arc::from("func.zip");
+        let mut tasks = HashSet::new();
+
+        collect_update_tasks(None, Arc::clone(&bucket), Arc::clone(&key), &mut tasks)?;
+        collect_update_tasks(None, bucket, key, &mut tasks)?;
+
+        assert_eq!(1, tasks.len());
+        Ok(())
+    }
+
+    #[test]
+    fn test_collect_update_tasks_keeps_distinct_functions() -> Result<()> {
+        let bucket: Arc<str> = Arc::from("b");
+        let key: Arc<str> = Arc::from("shared.zip");
+        let mut tasks = HashSet::new();
+
+        collect_update_tasks(
+            Some("a,b,c".to_string()),
+            Arc::clone(&bucket),
+            Arc::clone(&key),
+            &mut tasks,
+        )?;
+
+        assert_eq!(3, tasks.len());
+        Ok(())
+    }
+
+    #[test]
+    fn test_collect_update_tasks_dedups_across_metadata_and_key() -> Result<()> {
+        let bucket: Arc<str> = Arc::from("b");
+        let key: Arc<str> = Arc::from("foo.zip");
+        let mut tasks = HashSet::new();
+
+        collect_update_tasks(
+            Some("foo".to_string()),
+            Arc::clone(&bucket),
+            Arc::clone(&key),
+            &mut tasks,
+        )?;
+        collect_update_tasks(None, bucket, key, &mut tasks)?;
+
+        assert_eq!(1, tasks.len());
+        Ok(())
+    }
+
+    #[test]
+    fn test_collect_update_tasks_distinct_keys_not_deduped() -> Result<()> {
+        let bucket: Arc<str> = Arc::from("b");
+        let mut tasks = HashSet::new();
+
+        collect_update_tasks(
+            Some("foo".to_string()),
+            Arc::clone(&bucket),
+            Arc::from("v1.zip"),
+            &mut tasks,
+        )?;
+        collect_update_tasks(
+            Some("foo".to_string()),
+            bucket,
+            Arc::from("v2.zip"),
+            &mut tasks,
+        )?;
+
+        assert_eq!(2, tasks.len());
         Ok(())
     }
 }


### PR DESCRIPTION
- update() wrapped futures in tokio::spawn, so update_function_code errors were dropped by try_join_all (only JoinError propagated). Drop the spawn so inner errors surface.
- get_function_names_from_md was masking real HeadObject failures (e.g. AccessDenied) as "no metadata". Propagate with context.
- Dedup (function, bucket, key) tuples before issuing updates, and retry up to 5x with backoff on ResourceConflictException.
- Move lambda::init out of the handler so it runs once at cold start instead of per invocation.
- Add an SQS DLQ wired as the Lambda async on_failure destination so failed S3-triggered invocations aren't dropped.
- Use Arc<str> for bucket/key shared across updates and drop the unnecessary Into<String>+Display generic on get_function_names.
- Narrow tokio features from "full" to the set actually used.
- Misc: publish="false" -> publish=false, double-slash in git dep URL, stale TF_VAR_aws_acct_id in README, misleading test name.