### PR TITLE
Clean up code, docs, and IAM scoping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,12 +26,13 @@ either from:
 1. Object metadata key `function.names` (comma-separated list for shared code)
 2. Object key name (strips `.zip` extension)
 
-The core update flow (`src/lib.rs:102-149`):
+The core update flow (the `update()` function in `src/lib.rs`):
 
 1. Extract AWS region from S3 event records
 2. Create AWS SDK clients for S3 and Lambda
-3. For each S3 record, determine target function names
-4. Concurrently update all target Lambda functions using `aws_sdk_lambda::Client::update_function_code()`
+3. For each S3 record, determine target function names and collect deduplicated update tasks
+4. Concurrently update all target Lambda functions using `aws_sdk_lambda::Client::update_function_code()`, retrying
+   with exponential backoff on `ResourceConflictException` (up to 3 attempts)
 
 ## Development Commands
 
@@ -47,13 +48,14 @@ The core update flow (`src/lib.rs:102-149`):
 
 ### Terraform Setup
 
-Set required environment variables:
+Terraform state uses per-region workspaces named `lambdupdate_<region>`. Source the appropriate env script to set
+`TF_VAR_aws_region` (the only required variable) and select the workspace:
 
 ```bash
-export TF_VAR_aws_region="us-east-1"
-export TF_VAR_aws_acct_id="123412341234"
-export TF_VAR_code_bucket="my-code-bucket"
+. env-us_east_1  # or env-us_east_2
 ```
+
+The AWS account ID and code bucket name are derived in `lambdupdate.tf` from the caller identity and region.
 
 Deploy infrastructure:
 
@@ -90,5 +92,5 @@ Comprehensive test suite in `src/lib.rs` covers:
 Run specific test:
 
 ```bash
-cargo test test_get_function_names_from_md
+cargo test test_get_function_names_from_key
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,6 +777,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -789,6 +790,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1344,6 +1357,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1813,7 +1832,6 @@ dependencies = [
  "aws-sdk-lambda",
  "aws-sdk-s3",
  "aws_lambda_events",
- "chrono",
  "clap",
  "futures",
  "jluszcz_rust_utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,11 @@ aws-config = { version = "1", features = ["behavior-version-latest"] }
 aws-sdk-lambda = { version = "1", features = ["behavior-version-latest"] }
 aws-sdk-s3 = { version = "1", features = ["behavior-version-latest"] }
 aws_lambda_events = "1"
-chrono = "0"
-clap = "4"
-futures = "0"
+clap = { version = "4", features = ["derive"] }
+futures = "0.3"
 jluszcz_rust_utils = { git = "https://github.com/jluszcz/rust-utils" }
 lambda_runtime = "1"
-log = "0"
+log = "0.4"
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 

--- a/env-us_east_1
+++ b/env-us_east_1
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+# Source this file, don't execute it: . env-us_east_1
 
 export TF_VAR_aws_region="us-east-1"
 terraform workspace select lambdupdate_us-east-1

--- a/env-us_east_2
+++ b/env-us_east_2
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+# Source this file, don't execute it: . env-us_east_2
 
 export TF_VAR_aws_region="us-east-2"
 terraform workspace select lambdupdate_us-east-2

--- a/lambdupdate.tf
+++ b/lambdupdate.tf
@@ -59,7 +59,7 @@ resource "aws_iam_role_policy_attachment" "cw_logs" {
 data "aws_iam_policy_document" "lambda" {
   statement {
     actions   = ["lambda:UpdateFunctionCode"]
-    resources = ["*"]
+    resources = ["arn:aws:lambda:${var.aws_region}:${data.aws_caller_identity.current.account_id}:function:*"]
   }
 }
 

--- a/src/lambda.rs
+++ b/src/lambda.rs
@@ -1,7 +1,7 @@
+use aws_lambda_events::s3::S3Event;
 use jluszcz_rust_utils::lambda;
 use lambda_runtime::{LambdaEvent, service_fn};
 use lambdupdate::{APP_NAME, update};
-use serde_json::{Value, json};
 
 #[tokio::main]
 async fn main() -> Result<(), lambda_runtime::Error> {
@@ -12,8 +12,7 @@ async fn main() -> Result<(), lambda_runtime::Error> {
     Ok(())
 }
 
-async fn function(event: LambdaEvent<Value>) -> Result<Value, lambda_runtime::Error> {
-    update(serde_json::from_value(event.payload)?).await?;
-
-    Ok(json!({}))
+async fn function(event: LambdaEvent<S3Event>) -> Result<(), lambda_runtime::Error> {
+    update(event.payload).await?;
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@ use aws_config::ConfigLoader;
 use aws_lambda_events::s3::{S3Event, S3EventRecord};
 use aws_sdk_lambda::config::Region;
 use aws_sdk_lambda::operation::update_function_code::UpdateFunctionCodeError;
-use chrono::Utc;
 use futures::future::try_join_all;
 use log::{debug, info, warn};
 use std::collections::{HashMap, HashSet};
@@ -27,26 +26,17 @@ const INITIAL_BACKOFF_MS: u64 = 500;
 ///
 /// This function constructs a minimal S3EventRecord with all required fields
 /// using JSON deserialization, since S3Event structs are non-exhaustive in
-/// aws_lambda_events 1.0+. The event time is set to the current UTC time.
-///
-/// # Arguments
-/// * `region` - AWS region (e.g., "us-east-1")
-/// * `bucket` - S3 bucket name
-/// * `key` - S3 object key
-///
-/// # Returns
-/// * `S3EventRecord` - A valid S3EventRecord with the specified parameters
+/// aws_lambda_events 1.0+. The event time is a fixed epoch timestamp; nothing
+/// downstream reads it.
 ///
 /// # Panics
 /// * Panics if JSON deserialization fails (should not happen with valid inputs)
 pub fn create_s3_event_record(region: &str, bucket: &str, key: &str) -> S3EventRecord {
-    let event_time = Utc::now().to_rfc3339();
-
     let json = serde_json::json!({
         "eventVersion": "2.0",
         "eventSource": "aws:s3",
         "awsRegion": region,
-        "eventTime": event_time,
+        "eventTime": "1970-01-01T00:00:00.000Z",
         "eventName": "ObjectCreated:Put",
         "userIdentity": {
             "principalId": "EXAMPLE"
@@ -72,19 +62,8 @@ pub fn create_s3_event_record(region: &str, bucket: &str, key: &str) -> S3EventR
     serde_json::from_value(json).expect("Failed to construct S3EventRecord from JSON")
 }
 
-/// Extracts the AWS region from S3 event records.
-///
-/// All records must be from the same region. Returns an error if no region is found
-/// or if records contain multiple different regions.
-///
-/// # Arguments
-/// * `records` - Slice of S3 event records to extract region from
-///
-/// # Returns
-/// * `Result<String>` - The AWS region if exactly one unique region is found
-///
-/// # Errors
-/// * Returns error if records contain 0 or multiple different regions
+/// Extracts the AWS region from S3 event records. All records must be from the
+/// same region; errors if zero or multiple distinct regions are found.
 fn get_region(records: &[S3EventRecord]) -> Result<String> {
     let regions = records
         .iter()
@@ -136,20 +115,8 @@ fn extract_function_names_from_metadata(
     metadata.and_then(|m| m.get(FUNCTION_NAME_MD_KEY).cloned())
 }
 
-/// Determines function names from object metadata or object key.
-///
-/// First tries to get function names from object metadata using the key "function.names".
-/// If not found, extracts the function name from the object key by stripping the ".zip" suffix.
-///
-/// # Arguments
-/// * `function_names_from_md` - Optional function names from object metadata
-/// * `key` - S3 object key to extract function name from if metadata is not available
-///
-/// # Returns
-/// * `Result<String>` - Comma-separated function names or single function name
-///
-/// # Errors
-/// * Returns error if no metadata is provided and the key doesn't end with ".zip"
+/// Determines function names from object metadata if present, falling back to the
+/// object key with its ".zip" suffix stripped (an error if the suffix is absent).
 fn get_function_names(function_names_from_md: Option<String>, key: &str) -> Result<String> {
     match function_names_from_md {
         Some(function_names) => {
@@ -167,16 +134,8 @@ fn get_function_names(function_names_from_md: Option<String>, key: &str) -> Resu
     }
 }
 
-/// Processes a comma-separated list of function names, trimming whitespace and filtering empty names.
-///
-/// # Arguments
-/// * `function_names` - Comma-separated string of function names
-///
-/// # Returns
-/// * `Result<Vec<String>>` - Vector of trimmed, non-empty function names
-///
-/// # Errors
-/// * Returns error if no valid function names are found after processing
+/// Splits a comma-separated list of function names, trimming whitespace and dropping
+/// empty entries; errors if nothing valid remains.
 fn process_function_names(function_names: &str) -> Result<Vec<String>> {
     let processed_names: Vec<String> = function_names
         .split(',')
@@ -333,14 +292,9 @@ pub async fn update(event: S3Event) -> Result<()> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use aws_lambda_events::s3::S3EventRecord;
     use std::collections::HashMap;
 
     const TEST_EVENT: &str = r#"{"Records":[{"eventVersion":"2.0","eventSource":"aws:s3","awsRegion":"us-west-2","eventTime":"1970-01-01T00:00:00.000Z","eventName":"ObjectCreated:Put","userIdentity":{"principalId":"EXAMPLE"},"requestParameters":{"sourceIPAddress":"127.0.0.1"},"responseElements":{"x-amz-request-id":"EXAMPLE123456789","x-amz-id-2":"EXAMPLE123/5678abcdefghijklambdaisawesome/mnopqrstuvwxyzABCDEFGH"},"s3":{"s3SchemaVersion":"1.0","configurationId":"testConfigRule","bucket":{"name":"my-s3-bucket","ownerIdentity":{"principalId":"EXAMPLE"},"arn":"arn:aws:s3:::example-bucket"},"object":{"key":"HappyFace.jpg","size":1024,"eTag":"0123456789abcdef0123456789abcdef","sequencer":"0A1B2C3D4E5F678901"}}}]}"#;
-
-    fn test_record(region: &str, bucket: &str, key: &str) -> S3EventRecord {
-        create_s3_event_record(region, bucket, key)
-    }
 
     #[test]
     fn test_deserialize() -> Result<()> {
@@ -367,11 +321,11 @@ mod test {
 
     #[test]
     fn test_get_region() -> Result<()> {
-        let mut records = vec![test_record("us-east-1", "foo", "bar")];
+        let mut records = vec![create_s3_event_record("us-east-1", "foo", "bar")];
 
         assert_eq!("us-east-1", get_region(&records)?);
 
-        records.push(test_record("us-east-1", "baz", "quux"));
+        records.push(create_s3_event_record("us-east-1", "baz", "quux"));
 
         assert_eq!("us-east-1", get_region(&records)?);
 
@@ -382,25 +336,19 @@ mod test {
     fn test_get_region_none() {
         let records = Vec::new();
 
-        let res = get_region(&records);
-        assert!(res.is_err());
-        if let Err(e) = res {
-            assert!(e.to_string().contains("Invalid region count"));
-        }
+        let e = get_region(&records).unwrap_err();
+        assert!(e.to_string().contains("Invalid region count"));
     }
 
     #[test]
     fn test_get_region_multiple() {
         let records = vec![
-            test_record("us-east-1", "foo", "bar"),
-            test_record("us-east-2", "baz", "quux"),
+            create_s3_event_record("us-east-1", "foo", "bar"),
+            create_s3_event_record("us-east-2", "baz", "quux"),
         ];
 
-        let res = get_region(&records);
-        assert!(res.is_err());
-        if let Err(e) = res {
-            assert!(e.to_string().contains("Invalid region count"));
-        }
+        let e = get_region(&records).unwrap_err();
+        assert!(e.to_string().contains("Invalid region count"));
     }
 
     #[test]
@@ -423,12 +371,8 @@ mod test {
 
     #[test]
     fn test_get_function_names_from_unzipped_key() {
-        let res = get_function_names(None, "bar");
-
-        assert!(res.is_err());
-        if let Err(e) = res {
-            assert!(e.to_string().contains("'.zip' not found"));
-        }
+        let e = get_function_names(None, "bar").unwrap_err();
+        assert!(e.to_string().contains("'.zip' not found"));
     }
 
     #[test]
@@ -478,11 +422,8 @@ mod test {
 
     #[test]
     fn test_process_function_names_empty_names() {
-        let result = process_function_names(",, ,");
-        assert!(result.is_err());
-        if let Err(e) = result {
-            assert!(e.to_string().contains("No valid function names found"));
-        }
+        let e = process_function_names(",, ,").unwrap_err();
+        assert!(e.to_string().contains("No valid function names found"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,74 +1,28 @@
 use anyhow::Result;
 use aws_lambda_events::s3::S3Event;
-use clap::{Arg, ArgAction, Command};
-use jluszcz_rust_utils::{Verbosity, set_up_logger};
+use clap::{ArgAction, Parser};
+use jluszcz_rust_utils::set_up_logger;
 use lambdupdate::{APP_NAME, create_s3_event_record, update};
 use log::debug;
 
-#[derive(Debug)]
+#[derive(Debug, Parser)]
+#[command(name = "LambdUpdate", version, author)]
 struct Args {
-    verbosity: Verbosity,
+    /// Verbose mode (-v for debug, -vv for trace logging).
+    #[arg(short, action = ArgAction::Count)]
+    verbosity: u8,
+
+    /// AWS region.
+    #[arg(short, long)]
     region: String,
+
+    /// S3 bucket name.
+    #[arg(short, long)]
     bucket: String,
+
+    /// S3 key name.
+    #[arg(short, long)]
     key: String,
-}
-
-fn parse_args() -> Args {
-    let matches = Command::new("LambdUpdate")
-        .version("0.1")
-        .author("Jacob Luszcz")
-        .arg(
-            Arg::new("verbosity")
-                .short('v')
-                .action(ArgAction::Count)
-                .help("Verbose mode (-v for debug, -vv for trace logging)."),
-        )
-        .arg(
-            Arg::new("region")
-                .short('r')
-                .long("region")
-                .required(true)
-                .help("AWS region."),
-        )
-        .arg(
-            Arg::new("bucket")
-                .short('b')
-                .long("bucket")
-                .required(true)
-                .help("S3 bucket name."),
-        )
-        .arg(
-            Arg::new("key")
-                .short('k')
-                .long("key")
-                .required(true)
-                .help("S3 key name."),
-        )
-        .get_matches();
-
-    let verbosity = matches.get_count("verbosity").into();
-
-    let region = matches
-        .get_one::<String>("region")
-        .cloned()
-        .expect("region argument is required");
-
-    let bucket = matches
-        .get_one::<String>("bucket")
-        .cloned()
-        .expect("bucket argument is required");
-
-    let key = matches
-        .get_one::<String>("key")
-        .cloned()
-        .expect("key argument is required");
-
-    Args {
-        verbosity,
-        region,
-        bucket,
-        key,
-    }
 }
 
 impl From<Args> for S3Event {
@@ -83,8 +37,8 @@ impl From<Args> for S3Event {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let args = parse_args();
-    set_up_logger(APP_NAME, module_path!(), args.verbosity)?;
+    let args = Args::parse();
+    set_up_logger(APP_NAME, module_path!(), args.verbosity.into())?;
     debug!("Args: {args:?}");
 
     update(args.into()).await?;


### PR DESCRIPTION
- CLAUDE.md: remove stale TF_VAR_aws_acct_id/code_bucket vars and line refs; document workspace env scripts and conflict-retry behavior
- Cargo.toml: pin 0.x crates to minor (futures 0.3, log 0.4) since the minor is the semver-breaking boundary pre-1.0; drop direct chrono dep
- tf: scope lambda:UpdateFunctionCode to account/region functions instead of *
- env scripts: drop shebang, note they must be sourced to export vars
- lambda.rs: type the handler as LambdaEvent<S3Event> instead of manually round-tripping through serde_json::Value
- main.rs: switch to clap derive; version now tracks Cargo.toml
- lib.rs: use a fixed epoch event time (drops chrono), trim rustdoc boilerplate on private fns, remove test_record indirection, use unwrap_err in error-path tests