### PR TITLE
chore: add github-actions to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,15 @@ updates:
           - "*"
     assignees:
       - "jluszcz"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      all-actions:
+        patterns:
+          - "*"
+    assignees:
+      - "jluszcz"


### PR DESCRIPTION
Add a github-actions ecosystem block to keep workflow actions updated, matching the plexport configuration.