### PR TITLE
chore: rename CI workflow to ci.yml and normalize build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy
+name: CI
 
 on:
   push:
@@ -15,7 +15,8 @@ on:
       - main
 
 jobs:
-  build-and-package:
+  build:
+    name: Build, Test & Lint
     runs-on: ubuntu-24.04-arm
 
     env:
@@ -63,7 +64,7 @@ jobs:
           retention-days: 1
 
   deploy-us-east-1:
-    needs: build-and-package
+    needs: build
 
     if: github.event_name == 'push'
     uses: ./.github/workflows/deploy-lambda.yml
@@ -73,7 +74,7 @@ jobs:
       aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
 
   deploy-us-east-2:
-    needs: build-and-package
+    needs: build
 
     if: github.event_name == 'push'
     uses: ./.github/workflows/deploy-lambda.yml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LambdUpdate
 
-[![Status Badge](https://github.com/jluszcz/LambdUpdate/actions/workflows/build-and-deploy.yml/badge.svg)](https://github.com/jluszcz/LambdUpdate/actions/workflows/build-and-deploy.yml)
+[![Status Badge](https://github.com/jluszcz/LambdUpdate/actions/workflows/ci.yml/badge.svg)](https://github.com/jluszcz/LambdUpdate/actions/workflows/ci.yml)
 
 LambdUpdate is a [Terraform](https://www.terraform.io) configuration and Rust Lambda which updates AWS
 [Lambda](https://aws.amazon.com/lambda/) functions when S3 code is uploaded to a code bucket. The Lambda


### PR DESCRIPTION
Rename build-and-deploy.yml to ci.yml and rename the build-and-package job to build (with an explicit "Build, Test & Lint" name) so the check name is consistent across repos.