### PR TITLE
ci: grant git history tools to Claude code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,6 @@ jobs:
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(git blame:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Summary
- Adds `git blame`, `git log`, `git show`, and `git diff` to the allowed Bash tools for the Claude code review workflow, mirroring the change made in the `todoer` project (00cc657e601d36449273dce2034036dc101f7166).

## Test plan
- [x] `git diff` reviewed — only the `allowedTools` line in `.github/workflows/claude-code-review.yml` changed
- [x] Pre-commit hooks passed locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)