### PR TITLE
chore(cli): infer long args and lint test code in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           sudo apt-get install -y musl-tools
           rustup target add ${{ env.BUILD_TARGET }}
           rustup update
-          rustup component add clippy
+          rustup component add clippy rustfmt
 
       - name: Dump Toolchain Info
         run: |
@@ -45,8 +45,11 @@ jobs:
       - name: Test
         run: cargo test --target ${{ env.BUILD_TARGET }}
 
+      - name: Format
+        run: cargo fmt --check
+
       - name: Lint
-        run: cargo clippy --target ${{ env.BUILD_TARGET }} -- -D warnings
+        run: cargo clippy --target ${{ env.BUILD_TARGET }} --all-targets -- -D warnings
 
       - name: Package
         if: github.event_name == 'push'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,9 +40,10 @@ The core update flow (the `update()` function in `src/lib.rs`):
 
 - `cargo build` - Build the project
 - `cargo fmt` - Format the source code
+- `cargo fmt --check` - Check formatting (same as CI)
 - `cargo test` - Run all tests
 - `cargo check` - Check for compilation errors without building
-- `cargo clippy -- -D warnings` - Run Rust linter for code quality checks
+- `cargo clippy --all-targets -- -D warnings` - Run Rust linter for code quality checks (same as CI)
 
 ## Deployment
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use lambdupdate::{APP_NAME, create_s3_event_record, update};
 use log::debug;
 
 #[derive(Debug, Parser)]
-#[command(name = "LambdUpdate", version, author)]
+#[command(name = "LambdUpdate", version, author, infer_long_args = true)]
 struct Args {
     /// Verbose mode (-v for debug, -vv for trace logging).
     #[arg(short, action = ArgAction::Count)]


### PR DESCRIPTION
Add infer_long_args to the clap derive attribute so unambiguous long-flag prefixes work, add a Format (cargo fmt --check) CI step before Lint, lint test code (--all-targets), and sync CLAUDE.md commands with CI.