### PR TITLE
ci: reliably post Claude review comment via track_progress

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,6 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'


### PR DESCRIPTION
Without `track_progress`, the review's summary comment depended on the model choosing to run `gh pr comment`, which is non-deterministic — so many PRs got no visible review comment despite the workflow running and succeeding. `track_progress: true` makes claude-code-action post and maintain the comment itself.