### PR TITLE
Remove stale lambdupdate.github.${region} deploy role

### DIFF
--- a/lambdupdate.tf
+++ b/lambdupdate.tf
@@ -133,41 +133,6 @@ data "aws_iam_policy_document" "github" {
   }
 }
 
-resource "aws_iam_policy" "github" {
-  name   = "lambdupdate.github.${var.aws_region}"
-  policy = data.aws_iam_policy_document.github.json
-}
-
-resource "aws_iam_role" "github" {
-  name = "lambdupdate.github.${var.aws_region}"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Effect = "Allow",
-        Principal = {
-          Federated = data.aws_iam_openid_connect_provider.github.arn
-        },
-        Action = "sts:AssumeRoleWithWebIdentity",
-        Condition = {
-          StringEquals = {
-            "token.actions.githubusercontent.com:aud" : "sts.amazonaws.com"
-          }
-          StringLike = {
-            "token.actions.githubusercontent.com:sub" : "repo:jluszcz/LambdUpdate:*"
-          },
-        }
-      }
-    ]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "github" {
-  role       = aws_iam_role.github.name
-  policy_arn = aws_iam_policy.github.arn
-}
-
 resource "aws_iam_policy" "github_deploy" {
   name   = "lambdupdate.github-deploy.${var.aws_region}"
   policy = data.aws_iam_policy_document.github.json


### PR DESCRIPTION
Follow-up to the Lambda deploy migration. `lambdupdate.github.${region}` is superseded by `lambdupdate.github-deploy.${region}`. Removes the three `aws_iam_*.github` resources; keeps the shared `data.*.github` sources (referenced by `github_deploy`). `terraform validate` passes.

**Apply in both regions then merge** (`. env-us_east_1 && terraform apply`, `. env-us_east_2 && terraform apply`). No workflow references the old role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)