### PR TITLE
fix: attempt every function update instead of cancelling siblings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,9 @@ The core update flow (the `update()` function in `src/lib.rs`):
 3. For each S3 record, determine target function names and collect deduplicated update tasks
 4. Concurrently update all target Lambda functions using `aws_sdk_lambda::Client::update_function_code()`, retrying
    with exponential backoff on `ResourceConflictException` (up to 3 attempts)
+5. Every target is attempted even when one fails — the results are folded by `aggregate_update_results` into a single
+   error naming each failed function. Use `join_all` here, never `try_join_all`: the latter drops the remaining
+   futures on the first error, which cancels in-flight updates for functions sharing the same artifact.
 
 ## Development Commands
 
@@ -98,6 +101,9 @@ Comprehensive test suite in `src/lib.rs` covers:
 - S3 event deserialization
 - Region extraction from event records
 - Function name resolution from metadata/object keys
+- Retry/conflict classification (`test_is_conflict_*`)
+- Update-task deduplication (`test_collect_update_tasks_*`)
+- Failure aggregation across functions (`test_aggregate_update_results_*`)
 - Error handling for invalid inputs
 
 Run specific test:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use aws_config::ConfigLoader;
 use aws_lambda_events::s3::{S3Event, S3EventRecord};
 use aws_sdk_lambda::config::Region;
 use aws_sdk_lambda::operation::update_function_code::UpdateFunctionCodeError;
-use futures::future::try_join_all;
+use futures::future::join_all;
 use log::{debug, info, warn};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -223,6 +223,36 @@ async fn update_code(
     Err(final_err).with_context(|| format!("UpdateFunctionCode failed for {function_name}"))
 }
 
+/// Folds per-function update results into a single outcome.
+///
+/// Every function is reported, not just the first to fail: a single permanently
+/// bad name (a renamed or deleted function) must not obscure which of its
+/// siblings also need attention. Failures are sorted by function name because
+/// the update tasks come out of a `HashSet` in arbitrary order.
+fn aggregate_update_results(results: Vec<(String, Result<()>)>) -> Result<()> {
+    let mut failures: Vec<_> = results
+        .into_iter()
+        .filter_map(|(function_name, result)| result.err().map(|err| (function_name, err)))
+        .collect();
+
+    if failures.is_empty() {
+        return Ok(());
+    }
+
+    failures.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+    let detail = failures
+        .iter()
+        .map(|(function_name, err)| format!("{function_name} ({err:#})"))
+        .collect::<Vec<_>>()
+        .join("; ");
+
+    Err(anyhow!(
+        "Failed to update {} function(s): {detail}",
+        failures.len()
+    ))
+}
+
 /// Main function to process S3 events and update Lambda functions.
 ///
 /// This function:
@@ -278,15 +308,20 @@ pub async fn update(event: S3Event) -> Result<()> {
 
     debug!("{} function(s) to update", update_tasks.len());
 
+    // join_all, not try_join_all: the latter drops the remaining futures on the
+    // first error, cancelling in-flight updates for functions that share this
+    // artifact. Every target is attempted, then the failures are aggregated.
     let update_futures = update_tasks
         .into_iter()
         .map(|(function_name, bucket, key)| {
-            update_code(lambda_client.clone(), function_name, bucket, key)
+            let lambda_client = lambda_client.clone();
+            async move {
+                let result = update_code(lambda_client, function_name.clone(), bucket, key).await;
+                (function_name, result)
+            }
         });
 
-    try_join_all(update_futures).await?;
-
-    Ok(())
+    aggregate_update_results(join_all(update_futures).await)
 }
 
 #[cfg(test)]
@@ -456,6 +491,60 @@ mod test {
     #[test]
     fn test_is_conflict_false_none() {
         assert!(!is_conflict(None));
+    }
+
+    #[test]
+    fn test_aggregate_update_results_all_succeeded() {
+        let results = vec![("a".to_string(), Ok(())), ("b".to_string(), Ok(()))];
+        assert!(aggregate_update_results(results).is_ok());
+    }
+
+    #[test]
+    fn test_aggregate_update_results_no_functions() {
+        assert!(aggregate_update_results(Vec::new()).is_ok());
+    }
+
+    #[test]
+    fn test_aggregate_update_results_names_the_failed_function() {
+        let results = vec![
+            ("good".to_string(), Ok(())),
+            (
+                "stale".to_string(),
+                Err(anyhow!("ResourceNotFoundException")),
+            ),
+        ];
+
+        let err = aggregate_update_results(results).expect_err("expected an error");
+        let message = format!("{err:#}");
+
+        assert!(message.contains("stale"), "{message}");
+        assert!(message.contains("ResourceNotFoundException"), "{message}");
+    }
+
+    #[test]
+    fn test_aggregate_update_results_reports_every_failure() {
+        // The point of the fix: one bad name must not hide the others, so every
+        // failure has to survive into the aggregated error.
+        let results = vec![
+            ("zeta".to_string(), Err(anyhow!("boom"))),
+            ("alpha".to_string(), Err(anyhow!("bang"))),
+            ("ok".to_string(), Ok(())),
+        ];
+
+        let err = aggregate_update_results(results).expect_err("expected an error");
+        let message = format!("{err:#}");
+
+        assert!(message.contains("alpha"), "{message}");
+        assert!(message.contains("zeta"), "{message}");
+        assert!(
+            message.contains('2'),
+            "should count both failures: {message}"
+        );
+        // Update tasks come out of a HashSet, so the order must not be arbitrary.
+        assert!(
+            message.find("alpha") < message.find("zeta"),
+            "failures should be sorted by name: {message}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes the high finding in the portfolio review: **silent partial deployments** (`src/lib.rs:287`).

`try_join_all` returns on the first `Err` and drops the remaining futures, which cancels in-flight `UpdateFunctionCode` calls. If one name in a shared `function.names` list is permanently bad — a renamed or deleted function returning `ResourceNotFoundException` — its siblings may never be updated at all, and S3's async retries keep hitting the same failure, so the partial deploy persists.

`join_all` runs every update to completion. `aggregate_update_results` then folds the outcomes into a single error naming each failed function, sorted by name so the message is deterministic despite the update tasks coming out of a `HashSet`.

The retry/backoff behavior for `ResourceConflictException` is unchanged.

### Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` (26 passing, up from 22) all pass. The four new tests were watched failing before `aggregate_update_results` existed; the one that carries the fix is `test_aggregate_update_results_reports_every_failure`, which asserts a second failure is not hidden by the first.

`CLAUDE.md` gains the "every target is attempted" step, the `join_all`-not-`try_join_all` rule, and the three test groups its Testing section had fallen behind on.

Not run: anything requiring AWS credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
