### PR TITLE
docs: mark LambdUpdate retired

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # LambdUpdate
 
+> **Retired 2026-08-02.** Lambda code deploys no longer go through this
+> service. `deploy-lambda.yml` in [jluszcz/github-utils][gh-utils] uploads the
+> artifact to the code bucket and calls `UpdateFunctionCode` itself. The
+> rationale is in that repo, under
+> `docs/superpowers/specs/2026-08-02-lambdupdate-retirement-design.md`.
+>
+> The one capability without a replacement is the `function.names` object
+> metadata key, which pointed a single artifact at several functions. No
+> project used it.
+
+[gh-utils]: https://github.com/jluszcz/github-utils
+
 [![Status Badge](https://github.com/jluszcz/LambdUpdate/actions/workflows/ci.yml/badge.svg)](https://github.com/jluszcz/LambdUpdate/actions/workflows/ci.yml)
 
 LambdUpdate is a [Terraform](https://www.terraform.io) configuration and Rust Lambda which updates AWS


### PR DESCRIPTION
## Summary

Add retirement notice to LambdUpdate README marking the service as retired as of 2026-08-02.

`deploy-lambda.yml` in github-utils now calls `UpdateFunctionCode` directly, so LambdUpdate is no longer invoked by any service.

**Important:** This PR must merge before the repo is archived, since archiving makes it read-only.

## Related

- Completes Task 11 of the LambdUpdate retirement plan
- Follows Task 10 (bucket notification removal)
- Remaining steps (terraform destroy, archive) are manual operations

🤖 Generated with Claude Code